### PR TITLE
Allow user to specify region in resource call

### DIFF
--- a/resources/remote_file_s3.rb
+++ b/resources/remote_file_s3.rb
@@ -82,8 +82,12 @@ rescue Errno::ENOENT
 end
 
 load_current_value do |new_resource|
-  # Load region from ohai data
-  new_resource.region = node['ec2']&.fetch('region', nil) || 'us-west-2'
+  # Load region from ohai data if no region was provided
+  if node['ec2'] && !new_resource.region
+    new_resource.region = node['ec2']&.fetch('region', nil)
+  elsif !new_resource.region
+    new_resource.region = 'us-west-2'
+  end
 
   deps(new_resource)
   stat = safe_stat(new_resource.path) || current_value_does_not_exist!


### PR DESCRIPTION
This update ensures that the region specified during the resource call in a recipe is actually used, rather than expecting that the `['ec2']['region']` key exists in the ohai data. It is backwards compatible to look at the `['ec2']['region']` key if no region is specified in the resource call.